### PR TITLE
Added Prefix for Gitalk Issue creation

### DIFF
--- a/src/theme/components/Comments.vue
+++ b/src/theme/components/Comments.vue
@@ -32,9 +32,15 @@ const runnable = () => {
       id: location.pathname.substring(0, 50), // Ensure uniqueness and length less than 50
       language: "en-IN",
       distractionFreeMode: true,
+      title: generateIssueTitle(),
     });
     gitalk.render("gitalk-container");
   }
+};
+
+const generateIssueTitle = () => {
+  const prefix = "[COMMENT]";
+  return `${prefix} ${document.title}`;
 };
 
 onContentUpdated(runnable);


### PR DESCRIPTION
I added the title option to the Gitalk constructor.
Also added a function to generate the issue title. Currently it's just using the prefix and the default value but I added it as function so future adjustments are easier.